### PR TITLE
Fix is_main checks for lua5.2

### DIFF
--- a/lua/l2dbus/init.lua
+++ b/lua/l2dbus/init.lua
@@ -48,7 +48,7 @@ end
 
 
 -- Determine the context in which the module is used
-if type(package.loaded[(...)]) ~= "userdata" then
+if require('is_main')() then
     -- The module is being run as a program
     main(arg)
 else

--- a/lua/l2dbus/init.lua
+++ b/lua/l2dbus/init.lua
@@ -48,7 +48,7 @@ end
 
 
 -- Determine the context in which the module is used
-if require('is_main')() then
+if require('l2dbus.is_main')() then
     -- The module is being run as a program
     main(arg)
 else

--- a/lua/l2dbus/is_main.lua
+++ b/lua/l2dbus/is_main.lua
@@ -1,0 +1,6 @@
+
+local function is_main()
+    return debug.getinfo(4) == nil
+end
+
+return is_main

--- a/lua/l2dbus/msgbusctrl.lua
+++ b/lua/l2dbus/msgbusctrl.lua
@@ -426,7 +426,7 @@ local function main(arg)
 end
 
 -- Determine the context in which the module is used
-if require('is_main')() then
+if require('l2dbus.is_main')() then
     -- The module is being run as a program
     main(arg)
 else

--- a/lua/l2dbus/msgbusctrl.lua
+++ b/lua/l2dbus/msgbusctrl.lua
@@ -426,7 +426,7 @@ local function main(arg)
 end
 
 -- Determine the context in which the module is used
-if type(package.loaded[(...)]) ~= "userdata" then
+if require('is_main')() then
     -- The module is being run as a program
     main(arg)
 else

--- a/lua/l2dbus/proxyctrl.lua
+++ b/lua/l2dbus/proxyctrl.lua
@@ -1087,7 +1087,7 @@ local function main(arg)
 end
 
 -- Determine the context in which the module is used
-if require('is_main')() then
+if require('l2dbus.is_main')() then
     -- The module is being run as a program
     main(arg)
 else

--- a/lua/l2dbus/proxyctrl.lua
+++ b/lua/l2dbus/proxyctrl.lua
@@ -1087,7 +1087,7 @@ local function main(arg)
 end
 
 -- Determine the context in which the module is used
-if type(package.loaded[(...)]) ~= "userdata" then
+if require('is_main')() then
     -- The module is being run as a program
     main(arg)
 else

--- a/lua/l2dbus/service.lua
+++ b/lua/l2dbus/service.lua
@@ -904,7 +904,7 @@ local function main(arg)
 end
 
 -- Determine the context in which the module is used
-if type(package.loaded[(...)]) ~= "userdata" then
+if require('is_main')() then
     -- The module is being run as a program
     main(arg)
 else

--- a/lua/l2dbus/service.lua
+++ b/lua/l2dbus/service.lua
@@ -904,7 +904,7 @@ local function main(arg)
 end
 
 -- Determine the context in which the module is used
-if require('is_main')() then
+if require('l2dbus.is_main')() then
     -- The module is being run as a program
     main(arg)
 else

--- a/lua/l2dbus/validate.lua
+++ b/lua/l2dbus/validate.lua
@@ -449,7 +449,7 @@ local function main(arg)
 end
 
 -- Determine the context in which the module is used
-if type(package.loaded[(...)]) ~= "userdata" then
+if require('is_main')() then
     -- The module is being run as a program
     main(arg)
 else

--- a/lua/l2dbus/validate.lua
+++ b/lua/l2dbus/validate.lua
@@ -449,7 +449,7 @@ local function main(arg)
 end
 
 -- Determine the context in which the module is used
-if require('is_main')() then
+if require('l2dbus.is_main')() then
     -- The module is being run as a program
     main(arg)
 else

--- a/lua/ldbus/init.lua
+++ b/lua/ldbus/init.lua
@@ -1050,7 +1050,7 @@ end
 
 
 -- Determine the context in which the module is usd
-if require('is_main')() then
+if require('l2dbus.is_main')() then
     -- The module is being run as a program
     main(arg)
 else

--- a/lua/ldbus/init.lua
+++ b/lua/ldbus/init.lua
@@ -1050,7 +1050,7 @@ end
 
 
 -- Determine the context in which the module is usd
-if type(package.loaded[(...)]) ~= "userdata" then
+if require('is_main')() then
     -- The module is being run as a program
     main(arg)
 else

--- a/lua/ldbus/is_main.lua
+++ b/lua/ldbus/is_main.lua
@@ -1,0 +1,6 @@
+
+local function is_main()
+    return debug.getinfo(4) == nil
+end
+
+return is_main

--- a/lua/ldbus/is_main.lua
+++ b/lua/ldbus/is_main.lua
@@ -1,6 +1,0 @@
-
-local function is_main()
-    return debug.getinfo(4) == nil
-end
-
-return is_main

--- a/lua/ldbus/proxy.lua
+++ b/lua/ldbus/proxy.lua
@@ -269,7 +269,7 @@ end
 
 
 -- Determine the context in which the module is usd
-if require('is_main')() then
+if require('l2dbus.is_main')() then
     -- The module is being run as a program
     main(arg)
 else

--- a/lua/ldbus/proxy.lua
+++ b/lua/ldbus/proxy.lua
@@ -269,7 +269,7 @@ end
 
 
 -- Determine the context in which the module is usd
-if type(package.loaded[(...)]) ~= "userdata" then
+if require('is_main')() then
     -- The module is being run as a program
     main(arg)
 else

--- a/lua/ldbus/service.lua
+++ b/lua/ldbus/service.lua
@@ -355,7 +355,7 @@ end
 
 
 -- Determine the context in which the module is usd
-if require('is_main')() then
+if require('l2dbus.is_main')() then
     -- The module is being run as a program
     main(arg)
 else

--- a/lua/ldbus/service.lua
+++ b/lua/ldbus/service.lua
@@ -355,7 +355,7 @@ end
 
 
 -- Determine the context in which the module is usd
-if type(package.loaded[(...)]) ~= "userdata" then
+if require('is_main')() then
     -- The module is being run as a program
     main(arg)
 else

--- a/test/test_is_main.lua
+++ b/test/test_is_main.lua
@@ -1,0 +1,11 @@
+------------------------------------------
+-- Test that the is_main() function is working correctly.
+-- This test must be called directly from the command line.
+------------------------------------------
+
+print('Testing is_main() for a main module..')
+assert(require('l2dbus.is_main')())
+
+print('Testing is_main() for a library module..')
+assert(require('test_is_main_lib') == false)
+

--- a/test/utils/test_is_main.lua
+++ b/test/utils/test_is_main.lua
@@ -1,0 +1,1 @@
+return require('l2dbus.is_main')()


### PR DESCRIPTION
In lua5.2 package.loaded will be filled only when the module returns.
Therefore this cannot be used anymore to main-module checks.

I provided a more portable solution (hopefully).
